### PR TITLE
Updated long to int in python 3

### DIFF
--- a/canarytools/models/devices.py
+++ b/canarytools/models/devices.py
@@ -164,7 +164,10 @@ class Device(CanaryToolsBase):
             value = parse(value)
 
         if key in ['uptime']:
-            value = long(value)
+            try:
+                value = long(value)
+            except NameError:
+                value = int(value)
 
         if key in ['reconnect_count', 'service_count']:
             value = int(value)


### PR DESCRIPTION
Issue: long as a type doesn't exist in python3

Solution: replaced with int in python3.