### PR TITLE
Add AWS API canarytoken kind

### DIFF
--- a/canarytools/models/canarytokens.py
+++ b/canarytools/models/canarytokens.py
@@ -200,3 +200,4 @@ class CanaryTokenKinds(object):
     DOC_MSWORD = 'doc-msword'
     WEB_IMAGE = 'web-image'
     WINDOWS_DIR = 'windows-dir'
+    AWS = 'aws-id'


### PR DESCRIPTION
Provides support for creating AWS API canary tokens. Confirmed this was successful with a simple python wrapper:

```
import canarytools
import sys

client = canarytools.Console('Our_Org', 'API_KEY')

result = client.tokens.create(
	memo=sys.argv[1], 
	kind=canarytools.CanaryTokenKinds.AWS)
```