### PR TITLE
Add missing token types, add token download method

### DIFF
--- a/canarytools/console.py
+++ b/canarytools/console.py
@@ -159,6 +159,7 @@ class Console(object):
         except requests.exceptions.ConnectionError:
             self.throw_connection_error()
         if raw_resp:
+            resp.raise_for_status()
             return resp
         return self.handle_response(resp.json(), parser)
 

--- a/canarytools/console.py
+++ b/canarytools/console.py
@@ -138,12 +138,13 @@ class Console(object):
             self.throw_connection_error()
         return self.handle_response(r.json(), parser)
 
-    def get(self, url, params, parser=None):
+    def get(self, url, params, parser=None, raw_resp=False):
         """Get request
 
         :param url: Url of the API endpoint
         :param params: List of parameters to be sent
         :param parser: The function used to parse JSON data into an specific object
+        :param raw_resp: If False, handle the response before returning, otherwise return raw response (e.g. for download)
         :return: Object(s) or a Result Indicator Object
         """
         try:
@@ -157,6 +158,8 @@ class Console(object):
                     complete * 1000, datetime=datetime.now(self.tz), response_code=resp.status_code), data=resp.text)
         except requests.exceptions.ConnectionError:
             self.throw_connection_error()
+        if raw_resp:
+            return resp
         return self.handle_response(resp.json(), parser)
 
     def delete(self, url, params, parser=None):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ All uses of the Canary Console API start by importing the library module and ins
 .. code-block:: python
 
     import canarytools
-    client = canarytools.Console('YOUR_DOMAIN', 'YOUR_API_KEY')
+    console = canarytools.Console('YOUR_DOMAIN', 'YOUR_API_KEY')
 
 Alternatively, you can download a configuration file from your console's *Canary Console API* settings tab.
 Place this file in your home directory (*~/* for Unix environments and *C:\\Users\\{Current User}\\*
@@ -45,7 +45,7 @@ token or the domain anywhere in your code.
 .. code-block:: python
 
     import canarytools
-    client = canarytools.Console()
+    console = canarytools.Console()
 
 You may also specify the timezone to be used to format time-specific data.
 


### PR DESCRIPTION
The console has the ability to generate more token types than the wrapper currently permits. Some are simply not in the documentation, others require the ability to specify additional parameters. Both have been added with this PR, along with a `.download()` method which is needed for a number of tokens such as the pdf, word/excel doc, and sensitive command tokens.


To test:
```python
import canarytools
console = canarytools.Console() # with creds if you don't have a config file in your ~/

t1 = console.tokens.create(memo="test", kind='doc-msexcel')
assert 'Payroll.xslx' == t1.download(filename='Payroll.xslx')
assert t1.canarytoken + '.xlsx' == t1.download()

t2 = console.tokens.create(memo="test", kind='sensitive-cmd', process_name='klist.exe')
regfile = t2.download()

t3 = console.tokens.create(memo="test", kind='aws-s3', s3_source_bucket='my_bucket', s3_log_bucket='my_log_bucket')
setup_script = t3.download()

t1.delete()
t2.delete()
t3.delete()
```