### PR TITLE
Added support for Cloned CSS tokens

### DIFF
--- a/canarytools/models/canarytokens.py
+++ b/canarytools/models/canarytokens.py
@@ -24,13 +24,14 @@ class CanaryTokens(object):
         s3_source_bucket=None,
         s3_log_bucket=None,
         process_name=None,
+        expected_referrer=None,
         ):
         """Create a new Canarytoken
 
         :param memo: Use this to remind yourself where you placed the Canarytoken
         :param flock_id: Create token in different flock. Defaults to: 'flock:default'
         :param kind: The type of Canarytoken. Supported classes currently are: 
-            aws-id, cloned-web, dns, doc-msword, http, 
+            aws-id, cloned-web, cloned-css, dns, doc-msword, http,
             doc-msexcel, msexcel-macro, doc-msword, msword-macro, 
             pdf-acrobat-reader, qr-code, sensitive-cmd, signed-exe, 
             slack-api, web-image, windows-dir, wireguard
@@ -41,6 +42,7 @@ class CanaryTokens(object):
         :param s3_source_bucket: S3 bucket to monitor for access (required when creating aws-s3 tokens)
         :param s3_log_bucket: S3 bucket where logs will be stored (required when creating aws-s3 tokens)
         :param process_name: Name of the process you want to monitor (required when creating sensitive-cmd tokens)
+        :param expected_referrer: Domain to be used in cloned-css tokens
         :return: A Result object
         :rtype: :class:`Result <Result>` object
 
@@ -70,6 +72,9 @@ class CanaryTokens(object):
 
         if process_name:
             params['process_name'] = process_name
+
+        if expected_referrer:
+            params['expected_referrer'] = expected_referrer
 
         # load image and send
         if web_image:
@@ -259,6 +264,7 @@ class CanaryToken(CanaryToolsBase):
 class CanaryTokenKinds(object):
     AWS = 'aws-id'
     AWSS3 = 'aws-s3'
+    CLONED_CSS = 'cloned-css'
     CLONED_WEB = 'cloned-web'
     DNS = 'dns'
     DOC_MSWORD = 'doc-msword'


### PR DESCRIPTION
## Proposed changes

This change adds support for `cloned-css` tokens to the Python SDK. Currently, there is no documentation available for creating these tokens via the API, and the required parameter `expected_referrer` is not allowed by the Python SDK.

I reverse-engineered the required parameter by inspecting the request in the Canary.Tools web console when creating a Cloned CSS Token directly.

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] [Linked to the relevant github issue or github discussion](https://github.com/thinkst/canarytools-python/issues/19)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...