### PR TITLE
Change the Canarytokens fetch method to retrieve tokens in batches

### DIFF
--- a/canarytools/models/canarytokens.py
+++ b/canarytools/models/canarytokens.py
@@ -6,7 +6,7 @@ from ..exceptions import InvalidParameterError
 import logging
 logger = logging.getLogger('canarytools')
 
-CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT = 5000
+CANARYTOKENS_PAGE_SIZE_LIMIT = 2500
 
 class CanaryTokens(object):
     def __init__(self, console):
@@ -127,7 +127,7 @@ class CanaryTokens(object):
         return self.console.get('canarytoken/fetch', params, self.parse)
 
     def all(self, include_endpoints=True):
-        """Fetch all Canarytokens using the paginate endpoint
+        """Fetch all Canarytokens in batches using the paginate endpoint
 
         :return: A list of Canarytoken objects
         :rtype: List of :class:`CanaryToken <CanaryToken>` objects
@@ -144,27 +144,21 @@ class CanaryTokens(object):
 
         while True:
             params = {
-                'limit': CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT,
+                'limit': CANARYTOKENS_PAGE_SIZE_LIMIT,
                 'render_transients': str(include_endpoints),
             }
+
             if cursor:
                 params['cursor'] = cursor
 
-            page_data = self.console.get('canarytokens/paginate', params, parser=lambda data: data)
-            page_tokens = page_data.get('canarytokens', [])
+            response = self.console.get('canarytokens/paginate', params, parser=dict)
 
-            for token in page_tokens:
-                all_tokens.append(CanaryToken.parse(self.console, token))
+            all_tokens.extend(
+                CanaryToken.parse(self.console, token)
+                for token in response.get('canarytokens', [])
+            )
 
-            if len(page_tokens) < CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT:
-                break
-
-            cursor_data = page_data.get('cursor')
-            if isinstance(cursor_data, dict):
-                cursor = cursor_data.get('next')
-            else:
-                cursor = cursor_data
-
+            cursor = (response.get('cursor') or {}).get('next')
             if not cursor:
                 break
 

--- a/canarytools/models/canarytokens.py
+++ b/canarytools/models/canarytokens.py
@@ -127,7 +127,7 @@ class CanaryTokens(object):
         return self.console.get('canarytoken/fetch', params, self.parse)
 
     def all(self, include_endpoints=True):
-        """Fetch all Canarytokens in batches using the paginate endpoint
+        """Fetch all Canarytokens
 
         :return: A list of Canarytoken objects
         :rtype: List of :class:`CanaryToken <CanaryToken>` objects
@@ -158,7 +158,7 @@ class CanaryTokens(object):
                 for token in response.get('canarytokens', [])
             )
 
-            cursor = (response.get('cursor') or {}).get('next')
+            cursor = response.get('cursor', {})
             if not cursor:
                 break
 

--- a/canarytools/models/canarytokens.py
+++ b/canarytools/models/canarytokens.py
@@ -6,6 +6,8 @@ from ..exceptions import InvalidParameterError
 import logging
 logger = logging.getLogger('canarytools')
 
+CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT = 5000
+
 class CanaryTokens(object):
     def __init__(self, console):
         """Initialize CanaryToken
@@ -125,7 +127,7 @@ class CanaryTokens(object):
         return self.console.get('canarytoken/fetch', params, self.parse)
 
     def all(self, include_endpoints=True):
-        """Fetch all Canarytokens
+        """Fetch all Canarytokens using the paginate endpoint
 
         :return: A list of Canarytoken objects
         :rtype: List of :class:`CanaryToken <CanaryToken>` objects
@@ -137,8 +139,36 @@ class CanaryTokens(object):
             >>> import canarytools
             >>> tokens = console.tokens.all()
         """
-        params = {'include_endpoints': str(include_endpoints)}
-        return self.console.get('canarytokens/fetch', params, self.parse)
+        cursor = None
+        all_tokens = []
+
+        while True:
+            params = {
+                'limit': CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT,
+                'render_transients': str(include_endpoints),
+            }
+            if cursor:
+                params['cursor'] = cursor
+
+            page_data = self.console.get('canarytokens/paginate', params, parser=lambda data: data)
+            page_tokens = page_data.get('canarytokens', [])
+
+            for token in page_tokens:
+                all_tokens.append(CanaryToken.parse(self.console, token))
+
+            if len(page_tokens) < CANARYTOKENS_FETCH_PAGE_SIZE_LIMIT:
+                break
+
+            cursor_data = page_data.get('cursor')
+            if isinstance(cursor_data, dict):
+                cursor = cursor_data.get('next')
+            else:
+                cursor = cursor_data
+
+            if not cursor:
+                break
+
+        return all_tokens
 
     def parse(self, data):
         """Parse JSON data


### PR DESCRIPTION
## Proposed changes

The Console API's `/canarytokens/fetch` endpoint is deprecated. The API will also return an error if the Console can't generate a response in time if a large enough amount of tokens are requested.

The fetch method will now use the `/canarytokens/paginate` endpoint to fetch Canarytokens in batches if a there are enough of them (>2500) on a Console.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

This change was tested against a Console with ~130k tokens, with the fetch method taking an average of ~271s to execute and return all of them.

Install the pip package in editable mode and then run this [script](https://phabricator.thinkst.com/P85):
```
$ python average_fetch_canarytokens_canarytools-python.py \
  --execute-amount 10\
  --domain xxxxx \
  --api-key xxxxx \
Run 1/10: success (258.111754s)
Run 2/10: success (203.803658s)
Run 3/10: success (273.444011s)
Run 4/10: success (292.863554s)
Run 5/10: success (246.830728s)
Run 6/10: success (201.223964s)
Run 7/10: success (299.996355s)
Run 8/10: success (328.235792s)
Run 9/10: success (228.794950s)
Run 10/10: success (385.340827s)
Average time per run: 271.864559s
```