### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/canarytools/__init__.py
+++ b/canarytools/__init__.py
@@ -21,4 +21,4 @@ from .models.settings import Settings
 
 
 __author__ = 'Thinkst Applied Research'
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='canarytools',
 
-    version='1.2.2',
+    version='1.2.3',
 
     description='An API for the Thinkst Canary Console',
     long_description=long_description,


### PR DESCRIPTION
Bump to version 1.2.3 after improving fetch all canarytokens method.